### PR TITLE
docs: Remove build instructions and external references from README

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2022-2025 OKX labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We welcome contributions! Please follow these steps:
 2. Add new documentation under the correct folder:
    - `overview.md` for product overviews
    - `guides.md` for step-by-step guides
-   - `technical-reference.md` for API and contract references
+   - `technical-reference.md` for contract references
 3. Add example contracts in the `examples/` directory.
 4. Open a Pull Request with a clear description of your changes.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# DEX Router Documentation
+
+This repository provides comprehensive documentation and example smart contracts for DEX Router products, supporting both EVM and Solana ecosystems.
+
+## Project Structure
+
+```
+docs/
+  docs/
+    contracts/
+      DEX-Router-EVM-V1/
+        guides.md
+        overview.md
+        technical-reference.md
+      DEX-Router-Solana-V1/
+        guides.md
+        overview.md
+        technical-reference.md
+  examples/
+    DEX-Router-EVM-V1/
+      foundry.toml
+      interface/
+        IDexRouter.sol
+        IDexRouterExactOut.sol
+      remappings.txt
+      src/
+        smartswap.sol
+        smartswapByInvest.sol
+        swapWrap.sol
+        uniswapV3swap.sol
+        uniswapV3SwapExactOutTo.sol
+        unxswap.sol
+        unxswapExactOutTo.sol
+    DEX-Router-Solana-V1/
+```
+
+- **docs/contracts/DEX-Router-EVM-V1/**: Documentation for the EVM version of the DEX Router, including overview, guides, and technical reference.
+- **docs/contracts/DEX-Router-Solana-V1/**: Documentation for the Solana version of the DEX Router, including overview, guides, and technical reference.
+- **examples/DEX-Router-EVM-V1/**: Example Solidity contracts and interfaces for the EVM DEX Router.
+- **examples/DEX-Router-Solana-V1/**: (Reserved for Solana contract examples.)
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) (for documentation tooling, if needed)
+- [Foundry](https://book.getfoundry.sh/) (for Solidity contract development)
+- [Solana CLI](https://docs.solana.com/cli/install-solana-cli-tools) (for Solana development, if needed)
+
+### Usage
+
+- Browse documentation in `docs/docs/contracts/` for both EVM and Solana routers.
+- Explore example smart contracts in the `docs/examples/` directory.
+
+## Contributing
+
+We welcome contributions! Please follow these steps:
+
+1. Pick the appropriate section for your addition (EVM or Solana, docs or examples).
+2. Add new documentation under the correct folder:
+   - `overview.md` for product overviews
+   - `guides.md` for step-by-step guides
+   - `technical-reference.md` for API and contract references
+3. Add example contracts in the `examples/` directory.
+4. Open a Pull Request with a clear description of your changes.
+
+## License
+
+[MIT](./LICENSE)


### PR DESCRIPTION
- Keep core project structure and contribution guidelines intact